### PR TITLE
feat: enable snyk security scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,10 @@
 version: 2.1
+only_maintainers: &only_maintainers
+  filters:
+    branches:
+      # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+      ignore: /pull\/[0-9]+/
+
 only_branches: &only_branches
   filters:
     branches:
@@ -63,23 +69,15 @@ workflows:
       - test:
         <<: *only_branches
       - security-code:
-          filters:
-            branches:
-              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-              ignore: /pull\/[0-9]+/
           name: Snyk code
           context:
-            - snyk
-          <<: *only_branches
+            - driftctl-snyk
+          <<: *only_maintainers
       - security-oss:
-          filters:
-            branches:
-              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-              ignore: /pull\/[0-9]+/
           name: Snyk test
           context:
-            - snyk
-          <<: *only_branches
+            - driftctl-snyk
+          <<: *only_maintainers
   release:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,9 @@
 version: 2.1
+only_branches: &only_branches
+  filters:
+    branches:
+      ignore:
+        - main
 orbs:
   snyk: snyk/snyk@1.1.2
 jobs:
@@ -56,10 +61,7 @@ workflows:
   push:
     jobs:
       - test:
-          filters:
-            branches:
-              ignore:
-                - main
+        <<: *only_branches
       - security-code:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  snyk: snyk/snyk@1.1.2
 jobs:
   build:
     docker:
@@ -29,6 +31,27 @@ jobs:
           name: "Publish Release on GitHub"
           command: |
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -n ${CIRCLE_TAG} ${CIRCLE_TAG} ./bin/
+  security-oss:
+    docker:
+        - image: cimg/go:1.16.2
+    steps:
+        - checkout
+        - snyk/scan:
+              severity-threshold: medium
+              monitor-on-build: true
+              project: ${CIRCLE_PROJECT_REPONAME}
+              organization: snyk-iac-group-seceng
+  security-code:
+    docker:
+        - image: cimg/go:1.17.2
+    steps:
+        - checkout
+        - snyk/scan:
+              command: code test
+              severity-threshold: medium
+              monitor-on-build: false
+              project: ${CIRCLE_PROJECT_REPONAME}
+              organization: snyk-iac-group-seceng
 workflows:
   push:
     jobs:
@@ -37,6 +60,24 @@ workflows:
             branches:
               ignore:
                 - main
+      - security-code:
+          filters:
+            branches:
+              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+              ignore: /pull\/[0-9]+/
+          name: Snyk code
+          context:
+            - snyk
+          <<: *only_branches
+      - security-oss:
+          filters:
+            branches:
+              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+              ignore: /pull\/[0-9]+/
+          name: Snyk test
+          context:
+            - snyk
+          <<: *only_branches
   release:
     jobs:
       - build:


### PR DESCRIPTION
Attempt to add snyk scanning for PRs that have been submitted by maintainers.

The contributor PRs (from forked repos) should be ignored by the filter.