### PR TITLE
Ignore a Snyk issue

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-GOLANG-GOLANGORGXSYSUNIX-3310442:
+    - '*':
+        reason: Transitive dependency cannot be upgraded due to constraints at the time of writing
+        expires: 2023-04-08T12:37:45.309Z
+        created: 2023-02-06T12:37:45.311Z
+patch: {}


### PR DESCRIPTION
`go get -u github.com/aws/aws-sdk-go` does not result in the vulnerable golang.org/x/sys (https://app.snyk.io/org/snyk-iac-group-seceng/project/7d4c1386-0eb0-4194-996e-648782a917a1?utm_source=slack) being upgraded everywhere due to transitive dependency constraints.