### PR TITLE
chore: secrets scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ only_branches: &only_branches
       ignore:
         - main
 orbs:
+  prodsec: snyk/prodsec-orb@1.0
   snyk: snyk/snyk@1.1.2
 jobs:
   build:
@@ -68,6 +69,11 @@ workflows:
     jobs:
       - test:
         <<: *only_branches
+      - prodsec/secrets-scan:
+          name: Scan repository for secrets
+          context:
+            - snyk-bot-slack
+          channel: group-infrastructure-as-code-alerts        
       - security-code:
           name: Snyk code
           context:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.16.2
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
Adds secrets scanning to the repository. The scan runs in the CI/CD pipeline and is provide as a pre-commit hook as well.